### PR TITLE
added new api call and modified current calls to allow admins to rate…

### DIFF
--- a/docs-core/src/main/java/com/sismics/docs/core/event/DocumentRatedAsyncEvent.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/event/DocumentRatedAsyncEvent.java
@@ -1,0 +1,30 @@
+package com.sismics.docs.core.event;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * Document rated event.
+ *
+ * @author bgamard
+ */
+public class DocumentRatedAsyncEvent extends UserEvent {
+    /**
+     * Document ID.
+     */
+    private String documentId;
+    
+    public String getDocumentId() {
+        return documentId;
+    }
+
+    public void setDocumentId(String documentId) {
+        this.documentId = documentId;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("documentId", documentId)
+            .toString();
+    }
+}


### PR DESCRIPTION
The following code integrates the applicant ratings into the existing Document API calls. The document creation and document retrieval call now handles the new GPA, skills, experience, and education fields. To add ratings to a document, I implemented a new API call "document/rate:id" to add new ratings to the document fields with proper authentication and error handling. 

Testing: Successfully compiled code with the backend branch. 

Resolves #3 


<img width="877" alt="image" src="https://user-images.githubusercontent.com/84806182/193982325-864d57eb-dcbe-436b-a132-3019361b6096.png">
